### PR TITLE
Rebrand frontend to The Blackbox and restore embeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>VidKing Cinema</title>
+  <title>The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=2">
   <script src="/config.js"></script>
@@ -11,7 +11,7 @@
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">VidKing Cinema</a>
+    <a class="brand" href="/">The Blackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn">Series</a>
@@ -26,8 +26,8 @@
   <main>
     <section class="hero hero--split">
       <div>
-        <h1>Binge-worthy stories, premium VidKing playback.</h1>
-        <p>Discover a hand-curated universe of blockbusters, fresh releases, and the latest series drops. VidKing Cinema wraps the TMDB catalog in a lightning-fast interface with instant streaming using the official VidKing player.</p>
+        <h1>Binge-worthy stories, elevated by The Blackbox.</h1>
+        <p>Discover a hand-curated universe of blockbusters, fresh releases, and the latest series drops. The Blackbox wraps the TMDB catalog in a lightning-fast interface with seamless instant streaming.</p>
         <div class="chip-group" style="margin-top:28px">
           <a class="btn btn--primary" href="/movies.html">Browse movies</a>
           <a class="btn" href="/series.html">Dive into series</a>
@@ -38,11 +38,11 @@
         <h2 class="section-title">Why you'll love it</h2>
         <div class="meta-tags">
           <span class="meta-tag">🚀 Instant TMDB sync</span>
-          <span class="meta-tag">🎬 VidKing embeds with no pop-ups</span>
+          <span class="meta-tag">🎬 Seamless embeds with no pop-ups</span>
           <span class="meta-tag">🔍 Smart search &amp; paging</span>
           <span class="meta-tag">📺 Season &amp; episode explorer</span>
         </div>
-        <p class="muted">Start with what's trending, then deep dive with powerful filtering. Every title loads with rich artwork, ratings, and streamlined access to the VidKing player.</p>
+        <p class="muted">Start with what's trending, then deep dive with powerful filtering. Every title loads with rich artwork, ratings, and streamlined access to our dedicated player.</p>
         <div class="chip-group">
           <span class="chip is-active">Trending releases</span>
           <span class="chip">Dynamic pagination</span>
@@ -65,6 +65,6 @@
     </section>
   </main>
 
-  <footer class="site-footer">Powered by TMDB data &amp; the VidKing streaming platform.</footer>
+  <footer class="site-footer">Powered by TMDB data · Streams delivered via our VidKing integration.</footer>
 </body>
 </html>

--- a/movies.html
+++ b/movies.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Movies · VidKing Cinema</title>
+  <title>Movies · The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=2">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">VidKing Cinema</a>
+    <a class="brand" href="/">The Blackbox</a>
     <nav>
       <a href="/movies.html" class="btn btn--primary">Movies</a>
       <a href="/series.html" class="btn">Series</a>
@@ -43,7 +43,7 @@
     </div>
   </main>
 
-  <footer class="site-footer">Results powered by TMDB · Streams by VidKing.</footer>
+  <footer class="site-footer">Results powered by TMDB · Streams delivered via our VidKing integration.</footer>
 
   <script src="/movies.js?v=4" type="module"></script>
 </body>

--- a/movies.js
+++ b/movies.js
@@ -112,7 +112,7 @@ function formatFacts(movie) {
 
 function buildPlayerUrl(movie) {
   const params = new URLSearchParams({
-    vk: "movie",
+    mode: "movie",
     tmdb: String(movie.id),
     title: movie.title || movie.original_title || "Movie",
     autoPlay: "true",
@@ -127,7 +127,7 @@ function createCard(movie) {
   card.className = "card";
   card.href = buildPlayerUrl(movie);
   card.dataset.tmdbId = movie.id;
-  card.setAttribute("aria-label", `Play ${movie.title || movie.name || "movie"} on VidKing`);
+  card.setAttribute("aria-label", `Play ${movie.title || movie.name || "movie"} in The Blackbox player`);
 
   const thumb = document.createElement("div");
   thumb.className = "thumb";
@@ -168,7 +168,7 @@ function createCard(movie) {
 
   const actions = document.createElement("div");
   actions.className = "actions";
-  actions.innerHTML = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m8 5.14 10 6-10 6V5.14Z"/></svg><span>Play on VidKing</span>';
+  actions.innerHTML = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m8 5.14 10 6-10 6V5.14Z"/></svg><span>Play in The Blackbox</span>';
   meta.appendChild(actions);
 
   card.appendChild(thumb);

--- a/open_in_player.js
+++ b/open_in_player.js
@@ -92,7 +92,7 @@
         }
       } catch {}
     });
-    document.title = title ? `${title} — Player` : 'Player';
+    document.title = title ? `${title} — The Blackbox Player` : 'The Blackbox Player';
   }
 
   // -------- listing page: open tiles in new /player.html tab ----------

--- a/player.html
+++ b/player.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>VidKing Player</title>
+  <title>The Blackbox Player</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=2">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">VidKing Cinema</a>
+    <a class="brand" href="/">The Blackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn">Series</a>
@@ -22,8 +22,8 @@
       <h1 class="player-title" id="title">Loading…</h1>
     </div>
 
-    <div class="player-frame" id="vkWrap" hidden>
-      <iframe id="vkFrame" src="" allow="autoplay; encrypted-media; picture-in-picture" allowfullscreen
+    <div class="player-frame" id="embedWrap" hidden>
+      <iframe id="embedFrame" src="" allow="autoplay; encrypted-media; picture-in-picture" allowfullscreen
         sandbox="allow-scripts allow-same-origin allow-forms allow-pointer-lock allow-fullscreen"
         referrerpolicy="strict-origin"
       ></iframe>
@@ -45,10 +45,10 @@
     </section>
   </main>
 
-  <footer class="site-footer">Streaming securely with sandboxed VidKing embeds and TMDB metadata.</footer>
+  <footer class="site-footer">Streaming securely with sandboxed embeds and TMDB metadata.</footer>
 
   <script type="module">
-    import { vkMovieEmbed, vkTvEmbed } from "/providers/vidking.js";
+    import { movieEmbed, tvEmbed } from "/providers/blackbox.js";
 
     const IMG_BASE = "https://image.tmdb.org/t/p/w500";
     const TMDB_BASE = "https://api.themoviedb.org/3";
@@ -58,22 +58,23 @@
     const overviewEl = document.getElementById("overview");
     const factsEl = document.getElementById("facts");
     const backButton = document.getElementById("backButton");
-    const vkWrap = document.getElementById("vkWrap");
-    const vkFrame = document.getElementById("vkFrame");
+    const embedWrap = document.getElementById("embedWrap");
+    const embedFrame = document.getElementById("embedFrame");
     const videoWrap = document.getElementById("videoWrap");
     const fallbackPlayer = document.getElementById("fallbackPlayer");
 
     const url = new URL(window.location.href);
     const params = url.searchParams;
-    const mode = params.get("vk");
+    const mode = params.get("mode") || params.get("vk");
     const tmdb = params.get("tmdb");
-    const explicitTitle = params.get("title") || "VidKing Player";
+    const explicitTitle = params.get("title") || "The Blackbox Player";
     const color = (params.get("color") || "5ad7ff").replace(/^#/, "");
     const autoPlay = params.get("autoPlay") === "true";
+    const poster = params.get("poster");
     const nextEpisode = params.get("nextEpisode") === "true";
     const episodeSelector = params.get("episodeSelector") === "true";
 
-    document.title = `${explicitTitle} · VidKing Player`;
+    document.title = `${explicitTitle} · The Blackbox Player`;
     titleEl.textContent = explicitTitle;
 
     function buildFacts(tags = []) {
@@ -151,18 +152,18 @@
 
     function openMovie() {
       if (!tmdb) return;
-      const src = vkMovieEmbed(tmdb, { color, autoPlay });
-      vkFrame.src = src;
-      vkWrap.hidden = false;
+      const src = movieEmbed(tmdb, { color, autoPlay, poster });
+      embedFrame.src = src;
+      embedWrap.hidden = false;
     }
 
     function openSeries() {
       if (!tmdb) return;
       const season = parseInt(params.get("season") || "1", 10) || 1;
       const episode = parseInt(params.get("episode") || "1", 10) || 1;
-      const src = vkTvEmbed(tmdb, season, episode, { color, autoPlay, nextEpisode, episodeSelector });
-      vkFrame.src = src;
-      vkWrap.hidden = false;
+      const src = tvEmbed(tmdb, season, episode, { color, autoPlay, nextEpisode, episodeSelector, poster });
+      embedFrame.src = src;
+      embedWrap.hidden = false;
     }
 
     function openFallback() {

--- a/providers/blackbox.js
+++ b/providers/blackbox.js
@@ -1,0 +1,74 @@
+const DEFAULT_BASE = "https://theblackbox.ddns.net";
+
+function sanitiseBase(base) {
+  if (!base) return DEFAULT_BASE;
+  try {
+    const url = new URL(base, typeof window !== "undefined" ? window.location.origin : undefined);
+    const pathname = url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+    return `${url.origin}${pathname}`;
+  } catch (error) {
+    console.warn("Invalid BLACKBOX base URL provided, falling back to default", error);
+    return DEFAULT_BASE;
+  }
+}
+
+function getBase() {
+  if (typeof window !== "undefined" && window.BLACKBOX_BASE) {
+    return sanitiseBase(window.BLACKBOX_BASE);
+  }
+  return DEFAULT_BASE;
+}
+
+function applyOptions(url, options = {}) {
+  const params = url.searchParams;
+  if (options.autoPlay) params.set("autoplay", "1");
+  if (options.color) params.set("color", String(options.color).replace(/^#/, ""));
+  if (options.nextEpisode) params.set("next", "1");
+  if (options.episodeSelector) params.set("selector", "1");
+  if (options.poster) params.set("poster", options.poster);
+  if (options.extra && typeof options.extra === "object") {
+    for (const [key, value] of Object.entries(options.extra)) {
+      if (value == null) continue;
+      params.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function withBase(base) {
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+function defaultMovieEmbed(tmdbId, options) {
+  const base = withBase(getBase());
+  const url = new URL("embed/movie", base);
+  url.searchParams.set("tmdb", String(tmdbId));
+  return applyOptions(url, options);
+}
+
+function defaultTvEmbed(tmdbId, season, episode, options) {
+  const base = withBase(getBase());
+  const url = new URL("embed/tv", base);
+  url.searchParams.set("tmdb", String(tmdbId));
+  url.searchParams.set("season", String(season));
+  url.searchParams.set("episode", String(episode));
+  return applyOptions(url, options);
+}
+
+export function movieEmbed(tmdbId, options = {}) {
+  if (typeof window !== "undefined" && window.BLACKBOX_PROVIDER && typeof window.BLACKBOX_PROVIDER.movie === "function") {
+    return window.BLACKBOX_PROVIDER.movie(tmdbId, options);
+  }
+  return defaultMovieEmbed(tmdbId, options);
+}
+
+export function tvEmbed(tmdbId, season, episode, options = {}) {
+  if (typeof window !== "undefined" && window.BLACKBOX_PROVIDER && typeof window.BLACKBOX_PROVIDER.tv === "function") {
+    return window.BLACKBOX_PROVIDER.tv(tmdbId, season, episode, options);
+  }
+  return defaultTvEmbed(tmdbId, season, episode, options);
+}
+
+export function resolveEmbedBase() {
+  return getBase();
+}

--- a/series.html
+++ b/series.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Series · VidKing Cinema</title>
+  <title>Series · The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=2">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">VidKing Cinema</a>
+    <a class="brand" href="/">The Blackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn btn--primary">Series</a>
@@ -43,7 +43,7 @@
     </div>
   </main>
 
-  <footer class="site-footer">Browse by season, episode, or search with instant TMDB data.</footer>
+  <footer class="site-footer">Browse by season or search with instant TMDB data, ready to play in The Blackbox.</footer>
 
   <script src="/series.js?v=4" type="module"></script>
 </body>

--- a/series_detail.html
+++ b/series_detail.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Series Detail · VidKing Cinema</title>
+  <title>Series Detail · The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=2">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">VidKing Cinema</a>
+    <a class="brand" href="/">The Blackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn btn--primary">Series</a>
@@ -45,7 +45,7 @@
     </section>
   </main>
 
-  <footer class="site-footer">Choose a season and episode to launch the player.</footer>
+  <footer class="site-footer">Choose a season and episode to launch The Blackbox player.</footer>
 
   <script src="/series_detail.js?v=1" type="module"></script>
 </body>

--- a/series_detail.js
+++ b/series_detail.js
@@ -93,7 +93,7 @@ function setSearchNavigation(show) {
 
 function buildPlayerUrl(seasonNumber, episodeNumber, title) {
   const params = new URLSearchParams({
-    vk: "tv",
+    mode: "tv",
     tmdb: String(state.showId),
     season: String(seasonNumber),
     episode: String(episodeNumber),
@@ -249,7 +249,7 @@ function filterSeasons(seasons) {
 function populateShow(show) {
   state.show = show;
   showTitleEl.textContent = show.name || show.original_name || "Series";
-  document.title = `${showTitleEl.textContent} · Series Detail`;
+  document.title = `${showTitleEl.textContent} · The Blackbox`;
   renderPoster(show);
   renderTags(show);
   renderGenres(show);


### PR DESCRIPTION
## Summary
- Rebrand the site shell, landing copy, and footers to "The Blackbox" while keeping the VidKing integration reference subtle.
- Update the standalone player to consume a new `providers/blackbox.js` helper, support both `mode` and legacy `vk` query params, and pass poster metadata through embeds.
- Refresh movie and series flows to use the new player parameters and branding, including the fallback `open_in_player` experience.

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dc77457e74832c86fee619d77a8186