### PR TITLE
Update Vidking embed helpers to use path URLs

### DIFF
--- a/providers/blackbox.js
+++ b/providers/blackbox.js
@@ -1,4 +1,4 @@
-const VIDKING_BASE = "https://www.vidking.net/";
+const VIDKING_ORIGIN = "https://www.vidking.net";
 
 function applyOptions(url, options = {}) {
   const params = url.searchParams;
@@ -17,17 +17,18 @@ function applyOptions(url, options = {}) {
 
 export function movieEmbed(tmdbId, options = {}) {
   if (!tmdbId) return "";
-  const url = new URL(`embed/movie/${encodeURIComponent(tmdbId)}`, VIDKING_BASE);
+  const base = `${VIDKING_ORIGIN}/embed/movie/${encodeURIComponent(tmdbId)}`;
+  const url = new URL(base);
   return applyOptions(url, options);
 }
 
 export function tvEmbed(tmdbId, season, episode, options = {}) {
   if (!tmdbId) return "";
-  const safeSeason = season == null ? "" : encodeURIComponent(season);
-  const safeEpisode = episode == null ? "" : encodeURIComponent(episode);
-  const url = new URL(
-    `embed/tv/${encodeURIComponent(tmdbId)}/${safeSeason || 1}/${safeEpisode || 1}`,
-    VIDKING_BASE,
-  );
+  const seasonSegment = season == null ? "1" : String(season);
+  const episodeSegment = episode == null ? "1" : String(episode);
+  const base = `${VIDKING_ORIGIN}/embed/tv/${encodeURIComponent(tmdbId)}/${encodeURIComponent(
+    seasonSegment,
+  )}/${encodeURIComponent(episodeSegment)}`;
+  const url = new URL(base);
   return applyOptions(url, options);
 }


### PR DESCRIPTION
## Summary
- update the Vidking movie embed helper to build path-style URLs from VIDKING_ORIGIN and append query parameters
- update the TV embed helper to include season and episode path segments with sane fallbacks
- manually verify the player loader continues to load the expected Vidking embeds for movie and TV titles

## Testing
- node -e "import('file://' + process.cwd() + '/providers/blackbox.js').then((m)=>{console.log('movie', m.movieEmbed('299534', {color: 'ff0000', autoPlay: true, progress: 120}));console.log('tv', m.tvEmbed('1399', 1, 2, {autoPlay: false, nextEpisode: true, episodeSelector: true, progress: 45}));})"
- manual verification of movie and TV player pages in browser_container


------
https://chatgpt.com/codex/tasks/task_e_68dd66543cbc832cb3f2e5a65bcc08ae