### PR TITLE
Handle legacy Vidking embed fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,7 @@
   <meta charset="utf-8">
   <title>The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="/style.css?v=3">
-  <script src="/config.js"></script>
-  <script>window.CLOUD_BASE="";</script>
-  <script src="/cloud.js"></script>
+  <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">

--- a/movies.html
+++ b/movies.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Movies · The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="/style.css?v=3">
+  <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">

--- a/movies.js
+++ b/movies.js
@@ -115,7 +115,7 @@ function buildPlayerUrl(movie) {
     mode: "movie",
     tmdb: String(movie.id),
     title: movie.title || movie.original_title || "Movie",
-    autoPlay: "true",
+    autoplay: "true",
     color: "14ff9f",
   });
   return `/player.html?${params.toString()}`;

--- a/player.html
+++ b/player.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>BLACKBOX Player</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="/style.css?v=3">
+  <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">
@@ -45,6 +45,8 @@
         id="embedFrame"
         src=""
         allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
+        referrerpolicy="no-referrer"
+        title="Vidking video player"
         allowfullscreen
       ></iframe>
     </div>
@@ -67,7 +69,7 @@
     import {
       movieEmbed,
       tvEmbed,
-    } from "/providers/blackbox.js";
+    } from "/providers/blackbox.js?v=5";
 
     const TMDB_BASE = "https://api.themoviedb.org/3";
     const TMDB_API_KEY = "b7d1cc8554fcab41e013428e2dc418de";
@@ -83,17 +85,183 @@
     const loadingIndicator = document.getElementById("loadingIndicator");
     const loadingText = document.getElementById("loadingText");
 
+    function toOptionalBoolean(value) {
+      if (value === undefined || value === null) return null;
+      if (typeof value === "boolean") return value;
+      if (typeof value === "string") {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) return null;
+        if (["false", "0", "no"].includes(normalized)) return false;
+        if (["true", "1", "yes"].includes(normalized)) return true;
+        return null;
+      }
+      return Boolean(value);
+    }
+
+    function parseProgressSeconds(value) {
+      if (value === undefined || value === null) return null;
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return null;
+      return Math.floor(numeric);
+    }
+
+    function parseLegacyVidkingUrl(raw) {
+      if (!raw || typeof raw !== "string") return null;
+      const trimmed = raw.trim();
+      if (!trimmed) return null;
+      if (!/^https?:\/\//i.test(trimmed)) return null;
+      let parsed;
+      try {
+        parsed = new URL(trimmed);
+      } catch (error) {
+        console.warn("Ignoring malformed legacy Vidking URL", raw, error);
+        return null;
+      }
+
+      if (!parsed.hostname || !parsed.hostname.toLowerCase().endsWith("theblackbox.watch")) {
+        return null;
+      }
+
+      const segments = parsed.pathname.split("/").filter(Boolean);
+      if (segments[0] !== "embed") return null;
+
+      const type = segments[1];
+      if (type !== "movie" && type !== "tv") return null;
+
+      const tmdb = parsed.searchParams.get("tmdb") || segments[2] || null;
+      if (!tmdb) return null;
+
+      const options = {};
+      const color = parsed.searchParams.get("color") || parsed.searchParams.get("colour");
+      if (color) options.color = color;
+
+      const autoplay = toOptionalBoolean(
+        parsed.searchParams.get("autoplay") ?? parsed.searchParams.get("autoPlay"),
+      );
+      if (autoplay != null) options.autoplay = autoplay;
+
+      const nextEpisode = toOptionalBoolean(
+        parsed.searchParams.get("nextepisode") ?? parsed.searchParams.get("nextEpisode"),
+      );
+      if (nextEpisode != null) options.nextEpisode = nextEpisode;
+
+      const episodeSelector = toOptionalBoolean(
+        parsed.searchParams.get("episodeselector") ?? parsed.searchParams.get("episodeSelector"),
+      );
+      if (episodeSelector != null) options.episodeSelector = episodeSelector;
+
+      const progress = parseProgressSeconds(parsed.searchParams.get("progress"));
+      if (progress != null) options.progress = progress;
+
+      if (type === "movie") {
+        return { mode: "movie", tmdb, options };
+      }
+
+      const season = parsed.searchParams.get("season") ?? segments[2] ?? null;
+      const episode = parsed.searchParams.get("episode") ?? segments[3] ?? null;
+
+      return {
+        mode: "tv",
+        tmdb,
+        season,
+        episode,
+        options,
+      };
+    }
+
     const url = new URL(window.location.href);
     const params = url.searchParams;
-    const mode = params.get("mode") || params.get("vk");
-    const tmdb = params.get("tmdb");
+    const rawVk = params.get("vk");
+    let mode = params.get("mode");
+    if (!mode && rawVk && !/^https?:/i.test(rawVk.trim())) {
+      mode = rawVk;
+    }
+
+    let tmdb = params.get("tmdb");
     const explicitTitle = params.get("title") || "BLACKBOX Player";
-    const color = (params.get("color") || "14ff9f").replace(/^#/, "");
-    const autoPlay = params.get("autoPlay") !== "false";
-    const nextEpisode = params.get("nextEpisode") === "true";
-    const episodeSelector = params.get("episodeSelector") === "true";
-    const seasonNumber = mode === "tv" ? parseInt(params.get("season") || "1", 10) || 1 : null;
-    const episodeNumber = mode === "tv" ? parseInt(params.get("episode") || "1", 10) || 1 : null;
+
+    const rawColorParam = params.get("color") || params.get("colour");
+    let color = (rawColorParam || "14ff9f").replace(/^#/, "");
+
+    const autoplayParam = params.has("autoplay") ? params.get("autoplay") : params.get("autoPlay");
+    let autoPlay = (() => {
+      const parsed = toOptionalBoolean(autoplayParam);
+      if (parsed == null) return true;
+      return parsed;
+    })();
+
+    const nextEpisodeParam = params.has("nextepisode")
+      ? params.get("nextepisode")
+      : params.get("nextEpisode");
+    let nextEpisode = toOptionalBoolean(nextEpisodeParam) ?? false;
+
+    const episodeSelectorParam = params.has("episodeselector")
+      ? params.get("episodeselector")
+      : params.get("episodeSelector");
+    let episodeSelector = toOptionalBoolean(episodeSelectorParam) ?? false;
+
+    const seasonParam = params.get("season");
+    const episodeParam = params.get("episode");
+
+    let seasonNumber = seasonParam != null ? parseInt(seasonParam, 10) : null;
+    if (!Number.isFinite(seasonNumber) || seasonNumber <= 0) seasonNumber = null;
+
+    let episodeNumber = episodeParam != null ? parseInt(episodeParam, 10) : null;
+    if (!Number.isFinite(episodeNumber) || episodeNumber <= 0) episodeNumber = null;
+
+    const progressParam = params.get("progress");
+    let forcedProgressSeconds = parseProgressSeconds(progressParam);
+
+    const legacyEmbedCandidate = (() => {
+      if (rawVk && /^https?:/i.test(rawVk.trim())) return rawVk.trim();
+      const embedParam = params.get("embed") || params.get("vkembed") || params.get("legacy");
+      if (embedParam && /^https?:/i.test(embedParam.trim())) return embedParam.trim();
+      return null;
+    })();
+
+    const legacyConfig = parseLegacyVidkingUrl(legacyEmbedCandidate);
+
+    if (legacyConfig) {
+      if (!mode || mode === rawVk) mode = legacyConfig.mode;
+      if (!tmdb) tmdb = legacyConfig.tmdb;
+
+      if (legacyConfig.mode === "tv") {
+        if (legacyConfig.season != null) {
+          const parsedSeason = parseInt(legacyConfig.season, 10);
+          if (Number.isFinite(parsedSeason) && parsedSeason > 0) seasonNumber = parsedSeason;
+        }
+        if (legacyConfig.episode != null) {
+          const parsedEpisode = parseInt(legacyConfig.episode, 10);
+          if (Number.isFinite(parsedEpisode) && parsedEpisode > 0) episodeNumber = parsedEpisode;
+        }
+      }
+
+      if (legacyConfig.options) {
+        if (legacyConfig.options.color && !rawColorParam) {
+          color = String(legacyConfig.options.color).replace(/^#/, "");
+        }
+        if (legacyConfig.options.autoplay != null && autoplayParam == null) {
+          autoPlay = Boolean(legacyConfig.options.autoplay);
+        }
+        if (legacyConfig.options.nextEpisode != null && nextEpisodeParam == null) {
+          nextEpisode = Boolean(legacyConfig.options.nextEpisode);
+        }
+        if (legacyConfig.options.episodeSelector != null && episodeSelectorParam == null) {
+          episodeSelector = Boolean(legacyConfig.options.episodeSelector);
+        }
+        if (legacyConfig.options.progress != null && progressParam == null) {
+          forcedProgressSeconds = legacyConfig.options.progress;
+        }
+      }
+    }
+
+    if (mode !== "tv") {
+      seasonNumber = null;
+      episodeNumber = null;
+    } else {
+      if (seasonNumber == null) seasonNumber = 1;
+      if (episodeNumber == null) episodeNumber = 1;
+    }
 
     document.title = `${explicitTitle} · The Blackbox Player`;
     titleEl.textContent = explicitTitle;
@@ -281,12 +449,134 @@
       return `${minutes}:${pad(secs)}`;
     }
 
-    const playbackKey = buildProgressKey();
-    const savedProgress = readProgress(playbackKey);
-    let lastRecordedSecond = savedProgress ? savedProgress.seconds : null;
+    function toFiniteNumber(value) {
+      const num = Number(value);
+      return Number.isFinite(num) ? num : null;
+    }
 
-    if (savedProgress && savedProgress.seconds) {
-      setStatus(`Contacting Vidking… resuming from ${formatTime(savedProgress.seconds)}.`);
+    function normalizeVidkingPayload(raw) {
+      if (raw == null) return null;
+
+      let payload = raw;
+      if (typeof raw === "string") {
+        try {
+          payload = JSON.parse(raw);
+        } catch (error) {
+          console.warn("Ignored non-JSON message from Vidking", error);
+          return null;
+        }
+      }
+
+      if (!payload || typeof payload !== "object") return null;
+
+      const type = typeof payload.type === "string" ? payload.type.toUpperCase() : "";
+      if (type && type !== "PLAYER_EVENT") return null;
+
+      const candidates = [
+        payload.data,
+        payload.message && typeof payload.message === "object" ? payload.message : null,
+        payload.payload,
+        payload.detail,
+        payload.eventData,
+      ];
+
+      let details = null;
+      for (const candidate of candidates) {
+        if (candidate && typeof candidate === "object") {
+          details = candidate;
+          break;
+        }
+      }
+      if (!details && (!type || type === "PLAYER_EVENT")) {
+        details = payload;
+      }
+      if (!details || typeof details !== "object") return null;
+
+      const rawEvent =
+        details.event ??
+        details.name ??
+        details.type ??
+        (typeof payload.event === "string" ? payload.event : null);
+      if (!rawEvent) return null;
+
+      const eventKey = String(rawEvent).toLowerCase().replace(/[^a-z0-9]+/g, "");
+      const eventMap = {
+        play: "play",
+        playing: "play",
+        playbackstarted: "play",
+        start: "play",
+        started: "play",
+        pause: "pause",
+        paused: "pause",
+        buffering: "buffering",
+        buffer: "buffering",
+        loading: "buffering",
+        ready: "ready",
+        loaded: "ready",
+        prepared: "ready",
+        timeupdate: "timeupdate",
+        timeupdated: "timeupdate",
+        time: "timeupdate",
+        progress: "timeupdate",
+        tick: "timeupdate",
+        seeked: "seeked",
+        seeking: "seeked",
+        seek: "seeked",
+        ended: "ended",
+        complete: "ended",
+        completed: "ended",
+        finished: "ended",
+        error: "error",
+        failure: "error",
+      };
+      const normalizedEvent = eventMap[eventKey] || eventKey;
+
+      const rawMessage =
+        (typeof details.message === "string" && details.message) ||
+        (typeof details.error === "string" && details.error) ||
+        (typeof details.reason === "string" && details.reason) ||
+        (typeof payload.message === "string" && payload.message) ||
+        (typeof payload.error === "string" && payload.error) ||
+        null;
+
+      const id = details.id ?? payload.id ?? null;
+      const mediaType =
+        (details.mediaType || details.media_type || payload.mediaType || payload.media_type || "")
+          .toString()
+          .toLowerCase();
+      const season = details.season ?? details.seasonNumber ?? details.season_number ?? null;
+      const episode = details.episode ?? details.episodeNumber ?? details.episode_number ?? null;
+      const nextEpisode = toOptionalBoolean(details.nextEpisode ?? details.next_episode ?? null);
+
+      return {
+        event: normalizedEvent,
+        currentTime:
+          toFiniteNumber(details.currentTime ?? details.current_time ?? details.position ?? details.seconds ?? details.time),
+        duration: toFiniteNumber(
+          details.duration ?? details.totalDuration ?? details.length ?? details.runtime ?? details.total_time,
+        ),
+        message: rawMessage,
+        id,
+        mediaType,
+        season,
+        episode,
+        nextEpisode,
+      };
+    }
+
+    const playbackKey = buildProgressKey();
+    const savedProgress = forcedProgressSeconds == null ? readProgress(playbackKey) : null;
+    const resumeSeconds =
+      forcedProgressSeconds != null
+        ? forcedProgressSeconds
+        : savedProgress && typeof savedProgress.seconds === "number"
+        ? savedProgress.seconds
+        : null;
+    let lastRecordedSecond = typeof resumeSeconds === "number" ? resumeSeconds : null;
+
+    if (typeof resumeSeconds === "number" && resumeSeconds > 0) {
+      const verb = forcedProgressSeconds != null ? "starting" : "resuming";
+      setStatus(`Contacting Vidking… ${verb} at ${formatTime(resumeSeconds)}.`);
     }
 
     function loadVidkingEmbed(src) {
@@ -326,8 +616,8 @@
       }
       const src = movieEmbed(tmdb, {
         color,
-        autoPlay,
-        progress: savedProgress ? savedProgress.seconds : undefined,
+        autoplay: autoPlay,
+        progress: typeof resumeSeconds === "number" ? resumeSeconds : undefined,
       });
       loadVidkingEmbed(src);
     }
@@ -342,10 +632,10 @@
       const episode = episodeNumber || 1;
       const src = tvEmbed(tmdb, season, episode, {
         color,
-        autoPlay,
+        autoplay: autoPlay,
         nextEpisode,
         episodeSelector,
-        progress: savedProgress ? savedProgress.seconds : undefined,
+        progress: typeof resumeSeconds === "number" ? resumeSeconds : undefined,
       });
       loadVidkingEmbed(src);
     }
@@ -353,8 +643,30 @@
     function handlePlayerEvent(data = {}) {
       const eventName = data.event;
       if (!eventName) return;
-      const currentTime = Number(data.currentTime);
-      const duration = Number(data.duration);
+      const currentTime = toFiniteNumber(data.currentTime);
+      const duration = toFiniteNumber(data.duration);
+
+      if (eventName === "ready") {
+        setLoading(false);
+        const readyTime =
+          Number.isFinite(currentTime) && currentTime > 0
+            ? currentTime
+            : typeof resumeSeconds === "number"
+            ? resumeSeconds
+            : null;
+        if (readyTime != null && readyTime > 0) {
+          setStatus(`Vidking ready. Resume at ${formatTime(readyTime)} when you’re set.`);
+        } else {
+          setStatus("Vidking player ready. Press play to begin.");
+        }
+        return;
+      }
+
+      if (eventName === "buffering") {
+        setLoading(true, "Vidking buffering…");
+        setStatus("Vidking is buffering…");
+        return;
+      }
 
       if (eventName === "play") {
         setLoading(false);
@@ -392,7 +704,11 @@
         }
       } else if (eventName === "ended") {
         setLoading(false);
-        setStatus("Playback finished. Thanks for watching on Vidking.");
+        if (data.nextEpisode) {
+          setStatus("Episode complete. Awaiting the next installment…");
+        } else {
+          setStatus("Playback finished. Thanks for watching on Vidking.");
+        }
         if (playbackKey) {
           clearProgress(playbackKey);
           lastRecordedSecond = null;
@@ -408,19 +724,29 @@
     }
 
     function handlePlayerMessage(event) {
-      if (!event || typeof event.data !== "string") return;
-      let payload;
-      try {
-        payload = JSON.parse(event.data);
-      } catch {
-        return;
+      if (!event) return;
+      const payload = normalizeVidkingPayload(event.data);
+      if (!payload) return;
+      if (tmdb && payload.id && String(payload.id) !== String(tmdb)) return;
+      if (mode === "movie" && payload.mediaType && payload.mediaType !== "movie") return;
+      if (mode === "tv" && payload.mediaType && payload.mediaType !== "tv") return;
+      if (mode === "tv") {
+        if (
+          payload.season != null &&
+          Number.isFinite(Number(payload.season)) &&
+          Number(payload.season) !== seasonNumber
+        ) {
+          return;
+        }
+        if (
+          payload.episode != null &&
+          Number.isFinite(Number(payload.episode)) &&
+          Number(payload.episode) !== episodeNumber
+        ) {
+          return;
+        }
       }
-      if (!payload || payload.type !== "PLAYER_EVENT" || !payload.data) return;
-      const { id, mediaType } = payload.data;
-      if (tmdb && id && String(id) !== String(tmdb)) return;
-      if (mode === "movie" && mediaType && mediaType !== "movie") return;
-      if (mode === "tv" && mediaType && mediaType !== "tv") return;
-      handlePlayerEvent(payload.data);
+      handlePlayerEvent(payload);
     }
 
     window.addEventListener("message", handlePlayerMessage);

--- a/providers/blackbox.js
+++ b/providers/blackbox.js
@@ -1,33 +1,56 @@
-const VIDKING_BASE = "https://www.vidking.net/";
+const VIDKING_ORIGIN = "https://www.vidking.net";
+
+function coerceBoolean(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return undefined;
+    if (["false", "0", "no"].includes(normalized)) return false;
+    return true;
+  }
+  return Boolean(value);
+}
 
 function applyOptions(url, options = {}) {
   const params = url.searchParams;
-  if (options.color) params.set("color", String(options.color).replace(/^#/, ""));
-  if (options.autoPlay !== false && options.autoPlay !== "false") {
-    params.set("autoPlay", "true");
+  const color = options.color ?? options.colour;
+  if (color) params.set("color", String(color).replace(/^#/, ""));
+
+  const autoplayOption = coerceBoolean(options.autoplay ?? options.autoPlay);
+  if (autoplayOption !== undefined) {
+    params.set("autoplay", autoplayOption ? "true" : "false");
   }
-  if (options.nextEpisode) params.set("nextEpisode", "true");
-  if (options.episodeSelector) params.set("episodeSelector", "true");
+
+  if (coerceBoolean(options.nextEpisode ?? options.nextepisode)) {
+    params.set("nextepisode", "true");
+  }
+
+  if (coerceBoolean(options.episodeSelector ?? options.episodeselector)) {
+    params.set("episodeselector", "true");
+  }
+
   if (typeof options.progress === "number" && Number.isFinite(options.progress)) {
     const clamped = Math.max(0, Math.floor(options.progress));
     if (clamped > 0) params.set("progress", String(clamped));
   }
+
   return url.toString();
 }
 
 export function movieEmbed(tmdbId, options = {}) {
   if (!tmdbId) return "";
-  const url = new URL(`embed/movie/${encodeURIComponent(tmdbId)}`, VIDKING_BASE);
+  const base = `${VIDKING_ORIGIN}/embed/movie/${encodeURIComponent(tmdbId)}`;
+  const url = new URL(base);
   return applyOptions(url, options);
 }
 
 export function tvEmbed(tmdbId, season, episode, options = {}) {
   if (!tmdbId) return "";
-  const safeSeason = season == null ? "" : encodeURIComponent(season);
-  const safeEpisode = episode == null ? "" : encodeURIComponent(episode);
-  const url = new URL(
-    `embed/tv/${encodeURIComponent(tmdbId)}/${safeSeason || 1}/${safeEpisode || 1}`,
-    VIDKING_BASE,
-  );
+  const seasonSegment = season == null ? "1" : String(season);
+  const episodeSegment = episode == null ? "1" : String(episode);
+  const base = `${VIDKING_ORIGIN}/embed/tv/${encodeURIComponent(tmdbId)}/${encodeURIComponent(
+    seasonSegment,
+  )}/${encodeURIComponent(episodeSegment)}`;
+  const url = new URL(base);
   return applyOptions(url, options);
 }

--- a/series.html
+++ b/series.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Series · The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="/style.css?v=3">
+  <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">

--- a/series_detail.html
+++ b/series_detail.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Series Detail · The Blackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="/style.css?v=3">
+  <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">

--- a/series_detail.js
+++ b/series_detail.js
@@ -98,9 +98,9 @@ function buildPlayerUrl(seasonNumber, episodeNumber, title) {
     season: String(seasonNumber),
     episode: String(episodeNumber),
     title,
-    nextEpisode: "true",
-    episodeSelector: "true",
-    autoPlay: "true",
+    nextepisode: "true",
+    episodeselector: "true",
+    autoplay: "true",
     color: "14ff9f",
   });
   return `/player.html?${params.toString()}`;

--- a/style.css
+++ b/style.css
@@ -836,3 +836,62 @@ footer.site-footer {
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 540px) {
+  .topbar {
+    padding: 16px 20px 12px;
+  }
+
+  .topbar .brand {
+    font-size: 1rem;
+  }
+
+  .topbar nav {
+    order: 3;
+    display: grid;
+    width: 100%;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+  }
+
+  .topbar nav .btn,
+  .topbar nav a.btn {
+    width: 100%;
+  }
+
+  .hero {
+    padding: 56px 20px 40px;
+  }
+
+  .hero p {
+    font-size: 0.95rem;
+  }
+
+  .content {
+    padding: 0 20px 60px;
+  }
+
+  .ascii-banner {
+    padding: 16px;
+  }
+
+  .player-layout {
+    padding: 48px 20px 72px;
+  }
+
+  .player-title {
+    font-size: clamp(1.6rem, 6vw, 2.2rem);
+  }
+
+  .player-frame {
+    border-radius: 18px;
+  }
+
+  .player-details {
+    grid-template-columns: 1fr;
+  }
+
+  .chip-group {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- bust cached provider modules by versioning the player import
- translate legacy theblackbox.watch embed URLs into the new Vidking path format
- carry legacy autoplay, resume, and option flags forward for movies and series embeds

## Testing
- node -e "import('file://' + process.cwd() + '/providers/blackbox.js').then((m)=>{console.log('movie', m.movieEmbed('299534', {color: '5ad7ff'}));console.log('tv', m.tvEmbed('1399', 1, 2));})"

------
https://chatgpt.com/codex/tasks/task_e_68dd66543cbc832cb3f2e5a65bcc08ae