### PR TITLE
Rebrand UI to theblackbox and improve Vidking resume handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Vidking Hub</title>
+  <title>theblackbox · shadow signal</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">Vidking Hub</a>
+    <a class="brand" href="/">theblackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn">Series</a>
-      <a href="/player.html" class="btn btn--ghost">Vidking Player</a>
+      <a href="/player.html" class="btn btn--ghost">Vidking backend</a>
     </nav>
     <form class="search-bar" action="/movies.html" method="get">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 5 1.5-1.5-5-5Zm-6 0a4.5 4.5 0 1 1 4.5-4.5A4.5 4.5 0 0 1 9.5 14Z"/></svg>
@@ -27,18 +27,18 @@
 <span style="--i:3">  |    |   |   Y  \  ___/|    |   \  |__/ __ \\  \___|    < |    |   (  <_> >    < </span>
 <span style="--i:4">  |____|   |___|  /\\___  >______  /____(____  /\\___  >__|_ \|______  /\\____/__\\/\\_ \</span>
 <span style="--i:5">                \/     \/       \/          \/     \/     \/       \/            \/</span></pre>
-    <p class="ascii-subtitle">signal spliced · mirrors masked · indie-coded by the night shift</p>
+    <p class="ascii-subtitle">signal spliced · mirrors masked · theblackbox whispers on quiet bands</p>
   </section>
 
   <main>
     <section class="hero hero--split">
       <div>
-        <h1>Underground cinema stitched for the Vidking player.</h1>
-        <p>The feed stays alive thanks to a rotating roster of community mirrors, TMDB metadata, and a player that refuses to die. No studios, no pop-ups—just a lean interface for the night crowd.</p>
+        <h1>Underground cinema curated by theblackbox, streamed through the Vidking backend.</h1>
+        <p>theblackbox keeps the feed alive with rotating community mirrors, TMDB metadata, and a hardened Vidking pipeline that refuses to die. No studios, no pop-ups—just a lean interface for the night crowd.</p>
         <div class="chip-group" style="margin-top:28px">
           <a class="btn btn--primary" href="/movies.html">Browse the vault</a>
           <a class="btn" href="/series.html">Track down series</a>
-          <a class="btn btn--ghost" href="/player.html">Boot Vidking</a>
+          <a class="btn btn--ghost" href="/player.html">Ping the Vidking backend</a>
         </div>
       </div>
       <div class="glass-panel stack">
@@ -49,7 +49,7 @@
           <span class="meta-tag">🛠️ Offline-friendly UX</span>
           <span class="meta-tag">🎚️ Raw fallback stream option</span>
         </div>
-        <p class="muted">Dial in trending drops, quick-search the archives, or jump straight into a specific episode. Every click routes through the Vidking player with sandboxed embeds and a brutalist skin.</p>
+        <p class="muted">Dial in trending drops, quick-search the archives, or jump straight into a specific episode. Every click routes through a Vidking-powered sandbox while theblackbox keeps the interface brutal and quick.</p>
         <div class="chip-group">
           <span class="chip is-active">Trending heat</span>
           <span class="chip">Queue memory</span>
@@ -72,6 +72,6 @@
     </section>
   </main>
 
-  <footer class="site-footer">Powered by TMDB data · Mirrors rotated by the Vidking crew.</footer>
+  <footer class="site-footer">Powered by TMDB data · Playback relayed through the Vidking backend.</footer>
 </body>
 </html>

--- a/movies.html
+++ b/movies.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Movies · Vidking Hub</title>
+  <title>Movies · theblackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">Vidking Hub</a>
+    <a class="brand" href="/">theblackbox</a>
     <nav>
       <a href="/movies.html" class="btn btn--primary">Movies</a>
       <a href="/series.html" class="btn">Series</a>
-      <a href="/player.html" class="btn btn--ghost">Vidking Player</a>
+      <a href="/player.html" class="btn btn--ghost">Vidking backend</a>
     </nav>
     <div class="search-bar">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 5 1.5-1.5-5-5Zm-6 0a4.5 4.5 0 1 1 4.5-4.5A4.5 4.5 0 0 1 9.5 14Z"/></svg>
@@ -27,7 +27,7 @@
 <span style="--i:3">  |    |   |   Y  \  ___/|    |   \  |__/ __ \\  \___|    < |    |   (  <_> >    < </span>
 <span style="--i:4">  |____|   |___|  /\\___  >______  /____(____  /\\___  >__|_ \|______  /\\____/__\\/\\_ \</span>
 <span style="--i:5">                \/     \/       \/          \/     \/     \/       \/            \/</span></pre>
-    <p class="ascii-subtitle">feature vault · direct vidking embeds · zero-corporate gloss</p>
+    <p class="ascii-subtitle">feature vault · theblackbox interface · Vidking under the hood</p>
   </section>
 
   <main class="content">
@@ -53,7 +53,7 @@
     </div>
   </main>
 
-  <footer class="site-footer">Results powered by TMDB · Streams delivered by the Vidking player.</footer>
+  <footer class="site-footer">Results powered by TMDB · Streams delivered through the Vidking backend.</footer>
 
   <script src="/movies.js?v=4" type="module"></script>
 </body>

--- a/movies.js
+++ b/movies.js
@@ -126,7 +126,10 @@ function createCard(movie) {
   card.className = "card";
   card.href = buildPlayerUrl(movie);
   card.dataset.tmdbId = movie.id;
-  card.setAttribute("aria-label", `Play ${movie.title || movie.name || "movie"} in the Vidking player`);
+  card.setAttribute(
+    "aria-label",
+    `Stream ${movie.title || movie.name || "movie"} on theblackbox via the Vidking backend`,
+  );
 
   const thumb = document.createElement("div");
   thumb.className = "thumb";
@@ -167,7 +170,8 @@ function createCard(movie) {
 
   const actions = document.createElement("div");
   actions.className = "actions";
-  actions.innerHTML = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m8 5.14 10 6-10 6V5.14Z"/></svg><span>Play in Vidking</span>';
+  actions.innerHTML =
+    '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m8 5.14 10 6-10 6V5.14Z"/></svg><span>Stream via Vidking backend</span>';
   meta.appendChild(actions);
 
   card.appendChild(thumb);

--- a/open_in_player.js
+++ b/open_in_player.js
@@ -92,7 +92,9 @@
         }
       } catch {}
     });
-    document.title = title ? `${title} — Vidking Player` : 'Vidking Player';
+    document.title = title
+      ? `${title} — theblackbox (Vidking backend)`
+      : 'theblackbox · Vidking backend';
   }
 
   // -------- listing page: open tiles in new /player.html tab ----------

--- a/player.html
+++ b/player.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Vidking Player</title>
+  <title>theblackbox player · Vidking backend</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">Vidking Player</a>
+    <a class="brand" href="/">theblackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn">Series</a>
-      <a href="/player.html" class="btn btn--primary">Player</a>
+      <a href="/player.html" class="btn btn--primary">Vidking backend</a>
     </nav>
     <button class="btn btn--ghost" type="button" id="backButton">← Back</button>
   </header>
@@ -24,7 +24,7 @@
 <span style="--i:3">  |    |   |   Y  \  ___/|    |   \  |__/ __ \\  \___|    < |    |   (  <_> >    < </span>
 <span style="--i:4">  |____|   |___|  /\\___  >______  /____(____  /\\___  >__|_ \|______  /\\____/__\\/\\_ \</span>
 <span style="--i:5">                \/     \/       \/          \/     \/     \/       \/            \/</span></pre>
-    <p class="ascii-subtitle">direct vidking embeds · tmdb metadata · no detours</p>
+    <p class="ascii-subtitle">direct Vidking embeds · TMDB metadata · theblackbox shell</p>
   </section>
 
   <main class="player-layout">
@@ -35,9 +35,9 @@
     <div class="player-status" role="status">
       <div class="loading-indicator" id="loadingIndicator" hidden aria-hidden="true">
         <span class="loading-box" aria-hidden="true"></span>
-        <span class="loading-text" id="loadingText">Buffering Vidking stream…</span>
+        <span class="loading-text" id="loadingText">Buffering via the Vidking backend…</span>
       </div>
-      <p id="playerStatus">Preparing Vidking stream…</p>
+      <p id="playerStatus">Preparing playback through the Vidking backend…</p>
     </div>
 
     <div class="player-frame" id="embedWrap" hidden>
@@ -46,7 +46,7 @@
         src=""
         allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
         referrerpolicy="no-referrer"
-        title="Vidking video player"
+        title="Vidking backend player"
         allowfullscreen
         sandbox="allow-scripts allow-same-origin allow-forms allow-pointer-lock allow-orientation-lock allow-top-navigation-by-user-activation"
       ></iframe>
@@ -90,7 +90,7 @@
     const params = url.searchParams;
     const mode = params.get("mode") || params.get("vk");
     const tmdb = params.get("tmdb");
-    const explicitTitle = params.get("title") || "Vidking Player";
+    const explicitTitle = params.get("title") || "theblackbox player";
     const color = (params.get("color") || "14ff9f").replace(/^#/, "");
 
     const autoplayParam = params.has("autoplay") ? params.get("autoplay") : params.get("autoPlay");
@@ -122,7 +122,7 @@
       return Math.floor(numeric);
     })();
 
-    document.title = `${explicitTitle} · Vidking Player`;
+    document.title = `${explicitTitle} · theblackbox (Vidking backend)`;
     titleEl.textContent = explicitTitle;
 
     function buildFacts(tags = []) {
@@ -198,7 +198,7 @@
       }
     }
 
-    const DEFAULT_LOADING_LABEL = "Buffering Vidking stream…";
+    const DEFAULT_LOADING_LABEL = "Buffering via the Vidking backend…";
 
     function setStatus(message) {
       if (!statusEl) return;
@@ -438,17 +438,125 @@
 
     const playbackKey = buildProgressKey();
     const savedProgress = forcedProgressSeconds == null ? readProgress(playbackKey) : null;
-    const resumeSeconds =
+    const initialResumeSeconds =
       forcedProgressSeconds != null
         ? forcedProgressSeconds
         : savedProgress && typeof savedProgress.seconds === "number"
         ? savedProgress.seconds
         : null;
+    let resumeSeconds = initialResumeSeconds;
     let lastRecordedSecond = typeof resumeSeconds === "number" ? resumeSeconds : null;
+    let resumeHandshakeTriggered = false;
+    let playbackConfirmed = false;
+    let resumeMonitorId = null;
+    let resumeFallbackApplied = false;
 
     if (typeof resumeSeconds === "number" && resumeSeconds > 0) {
       const verb = forcedProgressSeconds != null ? "starting" : "resuming";
-      setStatus(`Contacting Vidking… ${verb} at ${formatTime(resumeSeconds)}.`);
+      setStatus(`Syncing with the Vidking backend… ${verb} at ${formatTime(resumeSeconds)}.`);
+    }
+
+    function postVidkingMessages(payloads = []) {
+      if (!Array.isArray(payloads) || !payloads.length) return;
+      if (!embedFrame || !embedFrame.contentWindow) return;
+      const target = embedFrame.contentWindow;
+      for (const payload of payloads) {
+        try {
+          target.postMessage(payload, "*");
+        } catch (error) {
+          console.warn("Unable to post message object to Vidking backend", error);
+        }
+        if (payload && typeof payload === "object") {
+          try {
+            target.postMessage(JSON.stringify(payload), "*");
+          } catch (error) {
+            // ignore JSON serialization failures
+          }
+        }
+      }
+    }
+
+    function sendVidkingSeek(seconds) {
+      if (!Number.isFinite(seconds) || seconds < 0) return;
+      const value = Math.max(0, Math.floor(seconds));
+      postVidkingMessages([
+        { type: "PLAYER_COMMAND", command: "seek", value },
+        { type: "PLAYER_COMMAND", action: "seek", position: value },
+        { event: "seek", time: value },
+      ]);
+    }
+
+    function sendVidkingPlay() {
+      postVidkingMessages([
+        { type: "PLAYER_COMMAND", command: "play" },
+        { type: "PLAYER_COMMAND", action: "play" },
+        { event: "play" },
+      ]);
+    }
+
+    function cancelResumeMonitor() {
+      if (resumeMonitorId != null) {
+        clearTimeout(resumeMonitorId);
+        resumeMonitorId = null;
+      }
+    }
+
+    function startResumeMonitor() {
+      if (!autoPlay) return;
+      cancelResumeMonitor();
+      resumeMonitorId = window.setTimeout(() => {
+        resumeMonitorId = null;
+        if (playbackConfirmed) return;
+        triggerResumeFallback();
+      }, 7000);
+    }
+
+    function triggerResumeFallback() {
+      if (resumeFallbackApplied) return;
+      resumeFallbackApplied = true;
+      if (playbackKey) {
+        clearProgress(playbackKey);
+      }
+      resumeSeconds = null;
+      lastRecordedSecond = null;
+      setStatus("Resume stalled. Starting fresh through the Vidking backend…");
+      sendVidkingSeek(0);
+      if (autoPlay) {
+        sendVidkingPlay();
+        startResumeMonitor();
+      }
+    }
+
+    function markPlaybackConfirmed(currentTime) {
+      playbackConfirmed = true;
+      cancelResumeMonitor();
+      if (Number.isFinite(currentTime) && playbackKey) {
+        lastRecordedSecond = Math.floor(currentTime);
+      }
+    }
+
+    function attemptResumeHandshake(readyTime) {
+      if (resumeHandshakeTriggered) return;
+      resumeHandshakeTriggered = true;
+
+      const resumeTarget =
+        Number.isFinite(readyTime) && readyTime > 0
+          ? Math.floor(readyTime)
+          : Number.isFinite(resumeSeconds) && resumeSeconds > 0
+          ? Math.floor(resumeSeconds)
+          : null;
+
+      if (resumeTarget != null) {
+        setStatus(`Vidking backend ready. Resuming at ${formatTime(resumeTarget)}…`);
+        sendVidkingSeek(resumeTarget);
+      } else {
+        setStatus("Vidking backend ready. Preparing playback…");
+      }
+
+      if (autoPlay) {
+        sendVidkingPlay();
+        startResumeMonitor();
+      }
     }
 
     function loadVidkingEmbed(src) {
@@ -456,7 +564,7 @@
       if (!src) {
         embedFrame.removeAttribute("src");
         embedWrap.hidden = true;
-        setStatus("Unable to prepare Vidking stream. Check the launch parameters.");
+        setStatus("Unable to prepare playback through the Vidking backend. Check the launch parameters.");
         setLoading(false);
         return;
       }
@@ -466,23 +574,23 @@
       window.requestAnimationFrame(() => {
         embedFrame.src = src;
       });
-      setStatus("Connecting to Vidking…");
-      setLoading(true, "Contacting Vidking…");
+      setStatus("Connecting to the Vidking backend…");
+      setLoading(true, "Contacting Vidking backend…");
     }
 
     if (embedFrame) {
       embedFrame.addEventListener("load", () => {
-        setStatus("Vidking player loaded. Waiting for playback…");
+        setStatus("Vidking backend loaded. Waiting for playback…");
       });
       embedFrame.addEventListener("error", () => {
         setLoading(false);
-        setStatus("Vidking embed failed to load. Please refresh or try again later.");
+        setStatus("Vidking backend embed failed to load. Please refresh or try again later.");
       });
     }
 
     function openMovie() {
       if (!tmdb) {
-        setStatus("Missing TMDB identifier for Vidking playback.");
+        setStatus("Missing TMDB identifier for Vidking backend playback.");
         setLoading(false);
         return;
       }
@@ -490,7 +598,7 @@
         color,
         autoplay: autoPlay,
         autoPlay,
-        progress: typeof resumeSeconds === "number" ? resumeSeconds : undefined,
+        progress: typeof initialResumeSeconds === "number" ? initialResumeSeconds : undefined,
         idleCheck: 0,
       });
       loadVidkingEmbed(src);
@@ -498,7 +606,7 @@
 
     function openSeries() {
       if (!tmdb) {
-        setStatus("Missing TMDB identifier for Vidking playback.");
+        setStatus("Missing TMDB identifier for Vidking backend playback.");
         setLoading(false);
         return;
       }
@@ -510,7 +618,7 @@
         autoPlay,
         nextEpisode,
         episodeSelector,
-        progress: typeof resumeSeconds === "number" ? resumeSeconds : undefined,
+        progress: typeof initialResumeSeconds === "number" ? initialResumeSeconds : undefined,
         idleCheck: 0,
       });
       loadVidkingEmbed(src);
@@ -524,37 +632,27 @@
 
       if (eventName === "ready") {
         setLoading(false);
-        const readyTime =
-          Number.isFinite(currentTime) && currentTime > 0
-            ? currentTime
-            : typeof resumeSeconds === "number"
-            ? resumeSeconds
-            : null;
-        if (readyTime != null && readyTime > 0) {
-          setStatus(`Vidking ready. Resume at ${formatTime(readyTime)} when you’re set.`);
-        } else {
-          setStatus("Vidking player ready. Press play to begin.");
-        }
+        const readyTime = Number.isFinite(currentTime) && currentTime > 0 ? currentTime : null;
+        attemptResumeHandshake(readyTime);
         return;
       }
 
       if (eventName === "buffering") {
-        setLoading(true, "Vidking buffering…");
-        setStatus("Vidking is buffering…");
+        setLoading(true, "Buffering via the Vidking backend…");
+        setStatus("Vidking backend is buffering…");
         return;
       }
 
       if (eventName === "play") {
+        markPlaybackConfirmed(currentTime);
         setLoading(false);
         if (Number.isFinite(currentTime) && currentTime > 0) {
-          setStatus(`Vidking playback started at ${formatTime(currentTime)}.`);
-          if (playbackKey) {
-            lastRecordedSecond = Math.floor(currentTime);
-          }
+          setStatus(`Playback started at ${formatTime(currentTime)} via the Vidking backend.`);
         } else {
-          setStatus("Vidking playback started.");
+          setStatus("Playback started via the Vidking backend.");
         }
       } else if (eventName === "timeupdate") {
+        markPlaybackConfirmed(currentTime);
         setLoading(false);
         if (playbackKey && Number.isFinite(currentTime) && currentTime >= 0) {
           if (lastRecordedSecond == null || Math.abs(currentTime - lastRecordedSecond) >= 5) {
@@ -571,6 +669,7 @@
           }
         }
       } else if (eventName === "pause") {
+        cancelResumeMonitor();
         if (Number.isFinite(currentTime) && currentTime > 0) {
           setStatus(`Paused at ${formatTime(currentTime)}.`);
         }
@@ -579,22 +678,24 @@
           lastRecordedSecond = Math.floor(currentTime);
         }
       } else if (eventName === "ended") {
+        markPlaybackConfirmed(currentTime);
         setLoading(false);
         if (data.nextEpisode) {
           setStatus("Episode complete. Awaiting the next installment…");
         } else {
-          setStatus("Playback finished. Thanks for watching on Vidking.");
+          setStatus("Playback finished. Thanks for watching with theblackbox + Vidking backend.");
         }
         if (playbackKey) {
           clearProgress(playbackKey);
           lastRecordedSecond = null;
         }
       } else if (eventName === "error") {
+        cancelResumeMonitor();
         setLoading(false);
         if (data.message) {
-          setStatus(`Vidking error: ${data.message}`);
+          setStatus(`Vidking backend error: ${data.message}`);
         } else {
-          setStatus("Vidking reported an unexpected error.");
+          setStatus("Vidking backend reported an unexpected error.");
         }
       }
     }
@@ -627,14 +728,14 @@
 
     window.addEventListener("message", handlePlayerMessage);
 
-    setLoading(true, "Contacting Vidking…");
+    setLoading(true, "Contacting Vidking backend…");
 
     if (mode === "movie") {
       openMovie();
     } else if (mode === "tv") {
       openSeries();
     } else {
-      setStatus("Provide a valid Vidking mode (movie or tv) with a TMDB id to begin playback.");
+      setStatus("Provide a valid Vidking backend mode (movie or tv) with a TMDB id to begin playback.");
       setLoading(false);
       if (embedWrap) embedWrap.hidden = true;
     }

--- a/series.html
+++ b/series.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Series · Vidking Hub</title>
+  <title>Series · theblackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">Vidking Hub</a>
+    <a class="brand" href="/">theblackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn btn--primary">Series</a>
-      <a href="/player.html" class="btn btn--ghost">Vidking Player</a>
+      <a href="/player.html" class="btn btn--ghost">Vidking backend</a>
     </nav>
     <div class="search-bar">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 5 1.5-1.5-5-5Zm-6 0a4.5 4.5 0 1 1 4.5-4.5A4.5 4.5 0 0 1 9.5 14Z"/></svg>
@@ -27,7 +27,7 @@
 <span style="--i:3">  |    |   |   Y  \  ___/|    |   \  |__/ __ \\  \___|    < |    |   (  <_> >    < </span>
 <span style="--i:4">  |____|   |___|  /\\___  >______  /____(____  /\\___  >__|_ \|______  /\\____/__\\/\\_ \</span>
 <span style="--i:5">                \/     \/       \/          \/     \/     \/       \/            \/</span></pre>
-    <p class="ascii-subtitle">serial signals · midnight drops · queue and play on Vidking</p>
+    <p class="ascii-subtitle">serial signals · midnight drops · play routed via Vidking</p>
   </section>
 
   <main class="content">
@@ -53,7 +53,7 @@
     </div>
   </main>
 
-  <footer class="site-footer">Browse by season with TMDB intel · every episode snaps into the Vidking player.</footer>
+  <footer class="site-footer">Browse by season with TMDB intel · every episode snaps into the Vidking backend.</footer>
 
   <script src="/series.js?v=4" type="module"></script>
 </body>

--- a/series_detail.html
+++ b/series_detail.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Series Detail · Vidking Hub</title>
+  <title>Series Detail · theblackbox</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/style.css?v=4">
 </head>
 <body class="app-shell">
   <header class="topbar">
-    <a class="brand" href="/">Vidking Hub</a>
+    <a class="brand" href="/">theblackbox</a>
     <nav>
       <a href="/movies.html" class="btn">Movies</a>
       <a href="/series.html" class="btn btn--primary">Series</a>
-      <a href="/player.html" class="btn btn--ghost">Vidking Player</a>
+      <a href="/player.html" class="btn btn--ghost">Vidking backend</a>
     </nav>
     <div class="search-bar">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 5 1.5-1.5-5-5Zm-6 0a4.5 4.5 0 1 1 4.5-4.5A4.5 4.5 0 0 1 9.5 14Z"/></svg>
@@ -27,7 +27,7 @@
 <span style="--i:3">  |    |   |   Y  \  ___/|    |   \  |__/ __ \\  \___|    < |    |   (  <_> >    < </span>
 <span style="--i:4">  |____|   |___|  /\\___  >______  /____(____  /\\___  >__|_ \|______  /\\____/__\\/\\_ \</span>
 <span style="--i:5">                \/     \/       \/          \/     \/     \/       \/            \/</span></pre>
-    <p class="ascii-subtitle">map the seasons · decode episodes · patch into the Vidking player</p>
+    <p class="ascii-subtitle">map the seasons · decode episodes · patch into Vidking via theblackbox</p>
   </section>
 
   <main class="player-layout" id="detailRoot">
@@ -55,7 +55,7 @@
     </section>
   </main>
 
-  <footer class="site-footer">Pick a season, lock an episode, and we’ll sling it to the Vidking player.</footer>
+  <footer class="site-footer">Pick a season, lock an episode, and we’ll sling it through the Vidking backend.</footer>
 
   <script src="/series_detail.js?v=1" type="module"></script>
 </body>

--- a/series_detail.js
+++ b/series_detail.js
@@ -246,7 +246,7 @@ function filterSeasons(seasons) {
 function populateShow(show) {
   state.show = show;
   showTitleEl.textContent = show.name || show.original_name || "Series";
-  document.title = `${showTitleEl.textContent} · Vidking Hub`;
+  document.title = `${showTitleEl.textContent} · theblackbox`;
   renderPoster(show);
   renderTags(show);
   renderGenres(show);


### PR DESCRIPTION
## Summary
- refresh landing, listing, and detail pages to spotlight theblackbox branding while referencing Vidking only as the backend provider
- update supporting scripts so labels, document titles, and accessibility copy reflect the new brand language
- enhance the player resume handshake by posting Vidking seek/play commands after ready and clearing stale progress if playback does not begin

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9960ffc0832cb6d16fcd577462c5