### PR TITLE
Relax health check auto-skip in player

### DIFF
--- a/player.html
+++ b/player.html
@@ -978,34 +978,20 @@ Not Available
           if (timeoutId != null) {
             window.clearTimeout(timeoutId);
           }
-          if (!response.ok) return false;
+          if (!response.ok) return null;
           const body = await response.text();
-          return parseHealthCheckBody(body);
+          return parseHealthCheckBody(body) ? true : null;
         })
         .catch((error) => {
           if (timeoutId != null) {
             window.clearTimeout(timeoutId);
           }
           console.warn("Health check failed", error);
-          return false;
+          return null;
         })
         .then((isHealthy) => {
           pendingHealthChecks.delete(index);
           if (isHealthy) return;
-          recordServerFailure(index);
-          if (activeServerIndex === index) {
-            const nextIndex = findNextServer(index);
-            if (nextIndex != null) {
-              setStatus(
-                `${describeServer(server)} failed the relay health check. Trying ${describeServer(
-                  servers[nextIndex],
-                )}…`,
-              );
-              activateServer(nextIndex);
-            } else {
-              handleExhaustedServers();
-            }
-          }
         });
       pendingHealthChecks.set(index, probePromise);
     }


### PR DESCRIPTION
### Motivation
- Prevent stream sources from being auto-skipped when transient health probe failures (CORS, non-OK responses, network errors) occur so valid providers aren't dropped prematurely.

### Description
- Update `startServerHealthCheck` so non-OK responses and fetch errors resolve to `null` instead of `false`, and stop calling `recordServerFailure` / auto-activating the next server unless a probe explicitly reports the embed as healthy (`true`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b027f500832c90fce381db62f7d3)